### PR TITLE
Add safety disclaimer to README and DMG installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 A local MCP server that exposes controlled AppleScript automation tools to MCP clients on macOS.
 
+> [!CAUTION]
+> **This software can read, create, modify, and delete your personal data** across Notes, Calendar, Reminders, Mail, Contacts, Messages, Photos, Music, Finder, and Safari.
+>
+> By running this server you are granting an AI model the ability to interact with your macOS applications on your behalf. Although multiple safety layers exist (operation modes, per-app allowlists, destructive-action confirmation), **no automated safeguard is foolproof**. An unexpected prompt, a misconfigured policy, or a model hallucination could result in **data loss, disclosure of private information, or unintended actions** such as sending messages or emails.
+>
+> **You are solely responsible for:**
+> - Reviewing and understanding the [configuration](#configuration) and [policy model](#policy-model) before enabling any app
+> - Starting in `readonly` mode and only escalating when you understand the consequences
+> - Keeping the number of enabled apps to the minimum you actually need
+> - Never running in `full` mode unattended
+>
+> This project is provided **as-is, with no warranty**. See [LICENSE](LICENSE).
+
 ## Overview
 
 MCP-AppleScript provides a secure bridge between the [Model Context Protocol](https://modelcontextprotocol.io/) and macOS automation via AppleScript. It consists of two components:

--- a/packages/mcp-server/src/exec/executor.ts
+++ b/packages/mcp-server/src/exec/executor.ts
@@ -116,7 +116,9 @@ export async function runExecutor(
       });
     });
 
-    // Write request JSON to stdin and close
+    // Write request JSON to stdin and close.
+    // Ignore EPIPE — the child may exit before reading all input.
+    child.stdin.on("error", () => {});
     const requestJson = JSON.stringify(request);
     child.stdin.write(requestJson);
     child.stdin.end();

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -52,6 +52,19 @@ cat > "$STAGING/INSTALL.txt" <<'INSTALL_EOF'
 MCP-AppleScript Bridge Server
 ==============================
 
+  ⚠️  WARNING — READ BEFORE USE  ⚠️
+
+  This software can read, create, modify, and delete your personal data
+  across Notes, Calendar, Reminders, Mail, Contacts, Messages, Photos,
+  Music, Finder, and Safari.
+
+  By running this server you grant an AI model the ability to interact
+  with your macOS applications. No automated safeguard is foolproof.
+  Start in readonly mode, enable only the apps you need, and never run
+  in full mode unattended.
+
+  Provided as-is with no warranty. See LICENSE.
+
 Installation:
   1. Copy "mcp-applescript" to /usr/local/bin/ (or another directory in your PATH):
        sudo cp mcp-applescript /usr/local/bin/


### PR DESCRIPTION
Add a strongly worded caution banner to README.md and the DMG INSTALL.txt, warning users that this server grants an AI model access to their personal data across 10 macOS apps.

Covers: data risk, model unpredictability, user responsibility (readonly default, minimal apps, no unattended full mode).

This was intended for PR #12 but landed after merge — cherry-picked here.